### PR TITLE
Add readonly support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Added readonly field support ([#29](https://github.com/sixlive/nova-text-copy-field/pull/29))
 
 ## [1.5.0] 2019-03-03
 ###  Added

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -6,6 +6,7 @@
                     class="flex-1 form-input form-input-bordered form-control"
                     :class="errorClasses"
                     :placeholder="field.name"
+                    :disabled="isReadonly"
                     v-model="value"
                 />
                 <copy-button


### PR DESCRIPTION
## Description
Add readonly() method support.
```
TextCopy::make('Key')->readonly(),
```

## Tasks
- [ ] Tests
- [ ] Documentation
- [x] Changlog Entry

## Related Issues

## Related PRs

## Steps to Verify Functionality
